### PR TITLE
自動更新の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(message){
     if ( message.image ) {
       var html =
-       `<div class="main__contents__talks">
+       `<div class="main__contents__talks" data-message-id=${message.id}>
        <div class="main__contents__talks__talk">
           <div class="main__contents__talks__talk__info">
             <div class="main__contents__talks__talk__info__talker">
@@ -24,7 +24,7 @@ $(function(){
       return html;
     } else {
       var html =
-       `<div class="main__contents__talks">
+       `<div class="main__contents__talks" data-message-id=${message.id}>
         <div class="main__contents__talks__talk">
           <div class="main__contents__talks__talk__info">
             <div class="main__contents__talks__talk__info__talker">
@@ -70,5 +70,33 @@ $(function(){
       alert("メッセージ送信に失敗しました");
     })
   })
+ 
+  var reloadMessages = function() {
+    var last_message_id = $('.main__contents__talks:last').data("message-id");
+    console.log(last_message_id)
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id} 
+    })
+
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.main__contents').append(insertHTML);
+        $('.main__contents').animate({ scrollTop: $('.main__contents')[0].scrollHeight});
+      }
+      })
+    .fail(function() {
+      alert('error');
+    });
+  };
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });
 

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,8 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,8 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end
+

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.main__contents__talks
+.main__contents__talks{data: {message: {id: message.id}}}
   .main__contents__talks__talk
     .main__contents__talks__talk__info
       .main__contents__talks__talk__info__talker

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.user_name @message.user.name
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,8 @@ Rails.application.routes.draw do
   end
   resources :groups, only: [:new, :create, :edit, :update, :index] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
#what
トークの自動更新機能を実装。
トークがオンタイムで反映されるようになる。

#why
自動更新機能がないとプッシュ式になり画面をリロードしない限り新しいトークが反映されないため。



![a1125d70b80ad6ac9c0107417d63a707](https://user-images.githubusercontent.com/44453318/81055523-d174fb80-8f03-11ea-8a3c-eb13d6eee0ba.gif)
